### PR TITLE
Allow full zipcode to be passed into validator and be valid

### DIFF
--- a/lib/postjoy/validator.rb
+++ b/lib/postjoy/validator.rb
@@ -16,6 +16,7 @@ module ActiveModel
       private
 
       def sanitized(value)
+        return value if options[:allow_extended] != true
         value.to_s.split('-').first
       end
     end

--- a/lib/postjoy/validator.rb
+++ b/lib/postjoy/validator.rb
@@ -8,9 +8,15 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        if !Postjoy.find(value)
+        unless Postjoy.find(sanitized(value))
           record.errors.add(attribute, options.fetch(:message), value: value)
         end
+      end
+
+      private
+
+      def sanitized(value)
+        value.to_s.split('-').first
       end
     end
   end


### PR DESCRIPTION
Currently if I pass in `Postjoy.find('XXXXX-XXXX')` it will always return nil. This makes the validator impossible to use in an app that automatically adds rooftop accuracy precision to zip codes with, let's say, a shipping provider. So this is a PR to fix this.

Also, if the `unless` thing isn't to your personal taste, please feel free to make edits. 😄 